### PR TITLE
feat: add onboarding flow for new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.7.0] - 2026-06-22
+
+### Added
+- **Onboarding:** 4-screen onboarding flow shown automatically on first launch
+  - Screen 1: Welcome — introduces PocketList
+  - Screen 2: Budget — explains budget tracking
+  - Screen 3: Import/Export — highlights sharing and PDF export
+  - Screen 4: Customization — themes, dark mode, multi-language
+  - Skip button on all screens, "Get Started" button on last screen
+  - Persists completion state in SharedPreferences
+  - Fully internationalized (English/Spanish)
+
 ## [3.6.0] - 2026-06-16
 
 ### Added

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -320,5 +320,16 @@
   "shareDialogTitle": "Share PocketList",
   "scanToDownload": "Scan the QR code to download the app",
   "copyLink": "Copy link",
-  "linkCopied": "Link copied to clipboard"
+  "linkCopied": "Link copied to clipboard",
+  "onboardingTitle1": "Welcome to PocketList!",
+  "onboardingDesc1": "Organize your shopping lists easily and quickly. Never forget anything.",
+  "onboardingTitle2": "Control your budget",
+  "onboardingDesc2": "Assign prices and budgets to your items to keep track of your spending.",
+  "onboardingTitle3": "Import and export",
+  "onboardingDesc3": "Share your lists with other users or generate professional PDFs of your purchases.",
+  "onboardingTitle4": "Customize your app",
+  "onboardingDesc4": "Choose from multiple themes, dark mode, and multi-language support.",
+  "onboardingSkip": "Skip",
+  "onboardingNext": "Next",
+  "onboardingStart": "Get Started"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -320,5 +320,16 @@
   "shareDialogTitle": "Compartir PocketList",
   "scanToDownload": "Escanea el código QR para descargar la app",
   "copyLink": "Copiar enlace",
-  "linkCopied": "Enlace copiado al portapapeles"
+  "linkCopied": "Enlace copiado al portapapeles",
+  "onboardingTitle1": "¡Bienvenido a PocketList!",
+  "onboardingDesc1": "Organiza tus listas de compras de forma fácil y rápida. Nunca olvides nada.",
+  "onboardingTitle2": "Controla tu presupuesto",
+  "onboardingDesc2": "Asigna precios y presupuestos a tus artículos para llevar el control de tus gastos.",
+  "onboardingTitle3": "Importa y exporta",
+  "onboardingDesc3": "Comparte tus listas con otros usuarios o genera PDFs profesionales de tus compras.",
+  "onboardingTitle4": "Personaliza tu app",
+  "onboardingDesc4": "Elige entre múltiples temas, modo oscuro y soporte multi-idioma.",
+  "onboardingSkip": "Omitir",
+  "onboardingNext": "Siguiente",
+  "onboardingStart": "Empezar"
 }

--- a/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
+++ b/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
@@ -9,7 +9,7 @@ import PackageDescription
 let package = Package(
     name: "FlutterGeneratedPluginSwiftPackage",
     platforms: [
-        .iOS("14.5")
+        .iOS("13.0")
     ],
     products: [
         .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:pocketlist/src/pages/settings/pages/user.dart';
 import 'package:pocketlist/src/pages/about/about_page.dart';
 import 'package:pocketlist/src/pages/about/pages/authorPage.dart';
 import 'package:pocketlist/src/pages/import_export_page.dart';
+import 'package:pocketlist/src/pages/onboarding/onboarding_page.dart';
 
 import 'dart:convert';
 import 'package:upgrader/upgrader.dart';
@@ -189,9 +190,10 @@ class DarkLightTheme extends StatelessWidget {
         }
         return supportedLocales.first;
       },
-      initialRoute: 'home',
+      initialRoute: prefs.onboardingSeen ? 'home' : 'onboarding',
       routes: {
         'home': (_) => const HomePage(),
+        'onboarding': (_) => const OnboardingPage(),
         'newList': (_) => ShoppingListPage(),
         'settings': (_) => const SettingPage(),
         'colorPage': (_) => ColorPage(),

--- a/lib/src/Shared_Prefs/Preferencias_user.dart
+++ b/lib/src/Shared_Prefs/Preferencias_user.dart
@@ -67,6 +67,14 @@ class PreferenciasUsuario {
     _prefs.setString('ultimaPagina', value);
   }
 
+  bool get onboardingSeen {
+    return _prefs.getBool('onboardingSeen') ?? false;
+  }
+
+  set onboardingSeen(bool value) {
+    _prefs.setBool('onboardingSeen', value);
+  }
+
   String get tempTotal {
     return _prefs.getString('tempTotal') ?? '0.00';
   }

--- a/lib/src/pages/onboarding/onboarding_page.dart
+++ b/lib/src/pages/onboarding/onboarding_page.dart
@@ -126,7 +126,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
                   // Next or Start button
                   _currentPage == _pages.length - 1
                       ? SizedBox(
-                          width: 160,
+                          width: double.infinity,
                           child: ElevatedButton(
                             onPressed: _onComplete,
                             style: ElevatedButton.styleFrom(

--- a/lib/src/pages/onboarding/onboarding_page.dart
+++ b/lib/src/pages/onboarding/onboarding_page.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:pocketlist/src/Shared_Prefs/Preferencias_user.dart';
+import 'package:pocketlist/src/localization/localization_constant.dart';
+import 'package:pocketlist/src/pages/home_page.dart';
+import 'package:pocketlist/src/pages/onboarding/onboarding_screen.dart';
+
+class OnboardingPage extends StatefulWidget {
+  const OnboardingPage({Key? key}) : super(key: key);
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  final PageController _pageController = PageController();
+  final prefs = PreferenciasUsuario();
+  int _currentPage = 0;
+
+  final List<_OnboardingData> _pages = [
+    _OnboardingData(
+      icon: Icons.shopping_cart,
+      titleKey: 'onboardingTitle1',
+      descriptionKey: 'onboardingDesc1',
+    ),
+    _OnboardingData(
+      icon: Icons.account_balance_wallet,
+      titleKey: 'onboardingTitle2',
+      descriptionKey: 'onboardingDesc2',
+    ),
+    _OnboardingData(
+      icon: Icons.file_download,
+      titleKey: 'onboardingTitle3',
+      descriptionKey: 'onboardingDesc3',
+    ),
+    _OnboardingData(
+      icon: Icons.palette,
+      titleKey: 'onboardingTitle4',
+      descriptionKey: 'onboardingDesc4',
+    ),
+  ];
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _onComplete() {
+    prefs.onboardingSeen = true;
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const HomePage()),
+    );
+  }
+
+  void _nextPage() {
+    _pageController.nextPage(
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Skip button
+            Align(
+              alignment: Alignment.topRight,
+              child: TextButton(
+                onPressed: _onComplete,
+                child: Text(
+                  getTranslated(context, 'onboardingSkip'),
+                  style: TextStyle(
+                    color: Colors.grey[500],
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+            ),
+            // PageView
+            Expanded(
+              child: PageView.builder(
+                controller: _pageController,
+                itemCount: _pages.length,
+                onPageChanged: (index) {
+                  setState(() {
+                    _currentPage = index;
+                  });
+                },
+                itemBuilder: (context, index) {
+                  final page = _pages[index];
+                  return OnboardingScreen(
+                    icon: page.icon,
+                    titleKey: page.titleKey,
+                    descriptionKey: page.descriptionKey,
+                  );
+                },
+              ),
+            ),
+            // Indicators and button
+            Padding(
+              padding: const EdgeInsets.fromLTRB(40, 0, 40, 40),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  // Page indicators
+                  Row(
+                    children: List.generate(
+                      _pages.length,
+                      (index) => Container(
+                        margin: const EdgeInsets.only(right: 8),
+                        width: _currentPage == index ? 24 : 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          color: _currentPage == index
+                              ? Theme.of(context).colorScheme.primary
+                              : Colors.grey[300],
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                    ),
+                  ),
+                  // Next or Start button
+                  _currentPage == _pages.length - 1
+                      ? SizedBox(
+                          width: 160,
+                          child: ElevatedButton(
+                            onPressed: _onComplete,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor:
+                                  Theme.of(context).colorScheme.primary,
+                              foregroundColor: Colors.white,
+                              padding: const EdgeInsets.symmetric(vertical: 16),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                            child: Text(
+                              getTranslated(context, 'onboardingStart'),
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        )
+                      : IconButton(
+                          onPressed: _nextPage,
+                          icon: Icon(
+                            Icons.arrow_forward,
+                            color: Theme.of(context).colorScheme.primary,
+                            size: 32,
+                          ),
+                        ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OnboardingData {
+  final IconData icon;
+  final String titleKey;
+  final String descriptionKey;
+
+  _OnboardingData({
+    required this.icon,
+    required this.titleKey,
+    required this.descriptionKey,
+  });
+}

--- a/lib/src/pages/onboarding/onboarding_page.dart
+++ b/lib/src/pages/onboarding/onboarding_page.dart
@@ -106,55 +106,55 @@ class _OnboardingPageState extends State<OnboardingPage> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  // Page indicators
-                  Row(
-                    children: List.generate(
-                      _pages.length,
-                      (index) => Container(
-                        margin: const EdgeInsets.only(right: 8),
-                        width: _currentPage == index ? 24 : 8,
-                        height: 8,
-                        decoration: BoxDecoration(
-                          color: _currentPage == index
-                              ? Theme.of(context).colorScheme.primary
-                              : Colors.grey[300],
-                          borderRadius: BorderRadius.circular(4),
+                  if (_currentPage == _pages.length - 1) ...[
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: _onComplete,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor:
+                              Theme.of(context).colorScheme.primary,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        child: Text(
+                          getTranslated(context, 'onboardingStart'),
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                  // Next or Start button
-                  _currentPage == _pages.length - 1
-                      ? SizedBox(
-                          width: double.infinity,
-                          child: ElevatedButton(
-                            onPressed: _onComplete,
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor:
-                                  Theme.of(context).colorScheme.primary,
-                              foregroundColor: Colors.white,
-                              padding: const EdgeInsets.symmetric(vertical: 16),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                            ),
-                            child: Text(
-                              getTranslated(context, 'onboardingStart'),
-                              style: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                        )
-                      : IconButton(
-                          onPressed: _nextPage,
-                          icon: Icon(
-                            Icons.arrow_forward,
-                            color: Theme.of(context).colorScheme.primary,
-                            size: 32,
+                  ] else ...[
+                    // Page indicators
+                    Row(
+                      children: List.generate(
+                        _pages.length,
+                        (index) => Container(
+                          margin: const EdgeInsets.only(right: 8),
+                          width: _currentPage == index ? 24 : 8,
+                          height: 8,
+                          decoration: BoxDecoration(
+                            color: _currentPage == index
+                                ? Theme.of(context).colorScheme.primary
+                                : Colors.grey[300],
+                            borderRadius: BorderRadius.circular(4),
                           ),
                         ),
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: _nextPage,
+                      icon: Icon(
+                        Icons.arrow_forward,
+                        color: Theme.of(context).colorScheme.primary,
+                        size: 32,
+                      ),
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/lib/src/pages/onboarding/onboarding_screen.dart
+++ b/lib/src/pages/onboarding/onboarding_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:pocketlist/src/localization/localization_constant.dart';
+
+class OnboardingScreen extends StatelessWidget {
+  final int screenIndex;
+  final IconData icon;
+  final String titleKey;
+  final String descriptionKey;
+
+  const OnboardingScreen({
+    Key? key,
+    required this.screenIndex,
+    required this.icon,
+    required this.titleKey,
+    required this.descriptionKey,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(40),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(24),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              icon,
+              size: 80,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 48),
+          Text(
+            getTranslated(context, titleKey),
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            getTranslated(context, descriptionKey),
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 16,
+              color: Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/pages/onboarding/onboarding_screen.dart
+++ b/lib/src/pages/onboarding/onboarding_screen.dart
@@ -2,14 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:pocketlist/src/localization/localization_constant.dart';
 
 class OnboardingScreen extends StatelessWidget {
-  final int screenIndex;
   final IconData icon;
   final String titleKey;
   final String descriptionKey;
 
   const OnboardingScreen({
     Key? key,
-    required this.screenIndex,
     required this.icon,
     required this.titleKey,
     required this.descriptionKey,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: A new Flutter project.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.6.0+16
+version: 3.7.0+17
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Adds a 4-screen onboarding that shows automatically on first launch, introducing the main features of PocketList:
- Welcome — app overview
- Budget — budget tracking
- Import/Export — sharing and PDF export
- Customization — themes, dark mode, multi-language
Changes:
- New OnboardingScreen reusable widget (icon + title + description)
- New OnboardingPage with PageView, skip, indicators, and navigation
- onboardingSeen preference in SharedPreferences for first-launch detection
- Conditional initialRoute in main.dart based on onboarding state
- Localization strings for onboarding (es/en)
Bump: 3.6.0+16 → 3.7.0+17